### PR TITLE
Use Git-native gitignore handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,9 @@ These settings work both in global config and in project file `"settings"`.
 ## Known limitations
 
 - Probably doesn’t work on Windows
-- `!` in `.gitignore` is not supported
-- Global `.gitignore` is not supported
+- `.gitignore` only works with Git installed
 - Sublime Text excludes are not supported
-- On large projects listing might take long time
+- On large projects without Git listing might take long time
 
 ## Credits
 


### PR DESCRIPTION
Closes #1 

This PR makes some changes to how executables are discovered:

- all workspace folders get processed one after the other. For each folder:
  - if `git` executable is in `$PATH` AND if the current folder is [in] a repo:
    - use `git ls-files` to find all executables inside the repo
  - if current folder is not in a Git repo or there is no `git`
    - use `os.walk` and check every file for executability
    - directories named `.git` are always ignored

This adds some breaking changes, namely:

- if Git is not available, `.gitignore` is not taken into account any more
  - I believe this makes sense, as you wouldn't really work with a Git-powered repo without Git available
- the methods counting the executables are generator functions (may speed things up)

TODO:

- [x] update docs